### PR TITLE
Added configuration option for serial number to deal with multiple tokens

### DIFF
--- a/command.c
+++ b/command.c
@@ -556,13 +556,24 @@ gpg_error_t cmd_null (assuan_context_t ctx, char *line)
 */
 gpg_error_t cmd_serialno (assuan_context_t ctx, char *line)
 {
+	cmd_data_t *data = (cmd_data_t *)assuan_get_pointer (ctx);
 	gpg_err_code_t error = GPG_ERR_GENERAL;
+	char *appid_plus_0;
+
+	if ((appid_plus_0 = (char *)malloc (strlen(data->config->application_id) + 3 )) == NULL) {
+                error = GPG_ERR_ENOMEM;
+                goto cleanup;
+        } 
+	strcpy(appid_plus_0,data->config->application_id);
+	strcat(appid_plus_0," 0");
+
+	
 
 	if (
 		(error = assuan_write_status (
 			ctx,
 			"SERIALNO",
-			OPENPGP_PKCS11_SERIAL " 0"
+			appid_plus_0
 		)) != GPG_ERR_NO_ERROR
 	) {
 		goto cleanup;
@@ -581,6 +592,8 @@ gpg_error_t cmd_learn (assuan_context_t ctx, char *line)
 	gpg_err_code_t error = GPG_ERR_GENERAL;
 	pkcs11h_certificate_id_list_t user_certificates = NULL;
 	pkcs11h_certificate_id_list_t issuer_certificates = NULL;
+	cmd_data_t *data = (cmd_data_t *)assuan_get_pointer (ctx);
+	const char * text = data->config->application_id;
 
 	(void)line;
 
@@ -588,7 +601,7 @@ gpg_error_t cmd_learn (assuan_context_t ctx, char *line)
 		(error = assuan_write_status (
 			ctx,
 			"SERIALNO",
-			OPENPGP_PKCS11_SERIAL
+			data->config->application_id
 		)) != GPG_ERR_NO_ERROR ||
 		(error = assuan_write_status (
 			ctx,
@@ -1371,13 +1384,14 @@ gpg_error_t cmd_getattr (assuan_context_t ctx, char *line)
 {
 	pkcs11h_certificate_id_list_t user_certificates = NULL;
 	gpg_err_code_t error = GPG_ERR_GENERAL;
+	cmd_data_t *data = (cmd_data_t *)assuan_get_pointer (ctx);
 
 	if (!strcmp (line, "SERIALNO")) {
 		if (
 			(error = assuan_write_status (
 				ctx,
 				"SERIALNO",
-				OPENPGP_PKCS11_SERIAL
+				data->config->application_id
 			)) != GPG_ERR_NO_ERROR
 		) {
 			goto cleanup;
@@ -1513,6 +1527,8 @@ gpg_error_t cmd_genkey (assuan_context_t ctx, char *line)
 	char *key = NULL;
 	size_t blob_size;
 	char timestamp[100] = {0};
+	cmd_data_t *data = (cmd_data_t *)assuan_get_pointer (ctx);
+	const char * text = data->config->application_id;
 
 	while (*line != '\x0' && !isdigit (*line)) {
 		if (*line == '-') {
@@ -1569,7 +1585,7 @@ gpg_error_t cmd_genkey (assuan_context_t ctx, char *line)
 		(error = assuan_write_status (
 			ctx,
 			"SERIALNO",
-			OPENPGP_PKCS11_SERIAL
+			data->config->application_id
 		)) != GPG_ERR_NO_ERROR ||
 		(error = get_cert_blob (
 			ctx,

--- a/dconfig.h
+++ b/dconfig.h
@@ -42,6 +42,8 @@ typedef struct {
 	char *openpgp_sign;
 	char *openpgp_encr;
 	char *openpgp_auth;
+	char *application_id;
+	char *pkcs11_serial;
 
 	struct {
 		char *name;

--- a/gnupg-pkcs11-scd.1
+++ b/gnupg-pkcs11-scd.1
@@ -200,6 +200,8 @@ provider-p1-library /usr/lib/pkcs11/p1.so
 #openpgp-sign 5C661B8C07CFD957F7D98D5B9A0F31D236BFAC2A
 #openpgp-encr D2DC0BD1EDD185969748B6025B452816F97CBA57
 #openpgp-auth A7B8C1A3A8F71FCEC018886F8767927B9C8D871F
+
+#serial-number 1234567890ABCD
 .Ed
 .Pp
 The following attributes can be set for each provider:
@@ -236,6 +238,10 @@ GNUPG INTEGRATION how to obtain.
 GNUPG INTEGRATION how to obtain.
 .It openpgp-auth
 [gnupg-2.0] Hex string (Upper letter, no space) SHA1 of authentication public key see
+GNUPG INTEGRATION how to obtain.
+.It serial-number
+[gnupg-2.0] 14 character Hex string (Upper letter, no space) representing the 
+serial number of the openpgp-card
 GNUPG INTEGRATION how to obtain.
 .El
 .Sh GNUPG INTEGRATION
@@ -275,6 +281,10 @@ Alternatively, you can add the existing keys as subkeys on an existing
 GPG master key:
 .Dl gpg --edit-key MASTER_KEY_ID
 .Dl addcardkey
+
+If you want to setup your keyring with two tokens, one for the master key and one for 
+daily usage you will need two config files with differnt serial numbers and differnt keys.
+Please exchange these files as soon as your pinentry programm asks you for the corresponding card.
 .It
 In order to reattach a key to smartcard, remove secret key using:
 .Dl gpg --delete-secret-keys KEY_ID


### PR DESCRIPTION
Hi,

when setting up a keychain with the master key on a differentr token it is necceary to tell gpg which keys are on wich token, therefore i added the config option "serial-number"