### PR TITLE
Add an option to flag decrypted data as being padded.

### DIFF
--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1403,7 +1403,10 @@ gpg_error_t cmd_pkdecrypt (assuan_context_t ctx, char *line)
 				&ptext_len
 			)
 		)) != GPG_ERR_NO_ERROR ||
-		(error = assuan_write_status(ctx, "PADDING", "0")) != GPG_ERR_NO_ERROR ||
+		(error = assuan_write_status(
+			ctx,
+		        "PADDING",
+			data->config->has_padding? "1" : "0")) != GPG_ERR_NO_ERROR ||
 		(error = assuan_send_data(ctx, ptext, ptext_len)) != GPG_ERR_NO_ERROR
 	) {
 		goto cleanup;

--- a/gnupg-pkcs11-scd/dconfig.c
+++ b/gnupg-pkcs11-scd/dconfig.c
@@ -149,6 +149,9 @@ dconfig_read (const char * const _file, dconfig_data_t * const config) {
 			trim (p);
 			config->openpgp_auth = strdup (p);
 		}
+		else if (prefix_is (line, "has_padding")) {
+		        config->has_padding = 1;
+		}
 		else if (prefix_is (line, "provider-")) {
 			char *name = strchr (line, '-')+1;
 			char *p;
@@ -218,7 +221,7 @@ dconfig_print (const dconfig_data_t * const config) {
 	int entry;
 
 	common_log (LOG_DEBUG, "config: debug=%d, verbose=%d", config->debug, config->verbose);
-	common_log (LOG_DEBUG, "config: pin_cache=%d", config->pin_cache);
+	common_log (LOG_DEBUG, "config: pin_cache=%d has_padding=%d", config->pin_cache, config->has_padding);
 
 	for (entry = 0;entry < DCONFIG_MAX_PROVIDERS;entry++) {
 		if (config->providers[entry].name != NULL) {

--- a/gnupg-pkcs11-scd/dconfig.h
+++ b/gnupg-pkcs11-scd/dconfig.h
@@ -38,6 +38,7 @@ typedef struct {
 	int debug;
 	int verbose;
 	int pin_cache;
+        int has_padding;
 
 	char *openpgp_sign;
 	char *openpgp_encr;
@@ -48,7 +49,7 @@ typedef struct {
 		char *library;
 		int allow_protected;
 		int cert_is_private;
-		unsigned private_mask;
+	        unsigned private_mask;
 	} providers[DCONFIG_MAX_PROVIDERS];
 } dconfig_data_t;
 

--- a/gnupg-pkcs11-scd/gnupg-pkcs11-scd.1
+++ b/gnupg-pkcs11-scd/gnupg-pkcs11-scd.1
@@ -194,6 +194,11 @@ file (lines beginning with # are comments):
 # Pin cache period in seconds; default is infinite.
 #pin-cache 20
 
+# The PKCS#11 library will return padded decrypted data.
+# A symptom that you might need to set this is signing
+# working but decryption failing.
+#has-padding
+
 # Comma-separated list of available provider names. Then set
 # attributes for each provider using the provider-[name]-attribute
 # syntax.


### PR DESCRIPTION
This patch fixes a problem that I had while using gnupg-pkcs11-scd with the TPM2 provider: https://github.com/tpm2-software/tpm2-pkcs11 . After generating a keypair and importing it into gpg I was able to sign but not to decrypt. The error was "gpg: cipher algorithm 0 is unknown or disabled". After looking into gnupg code I realized that the padding was interpreted as the symmetric key itself.

I did a bit of research and it looks like, see https://crypto.stackexchange.com/questions/9593/ckm-rsa-pkcs-vs-ckm-rsa-x-509-mechanisms-in-pkcs11 but also the PKCS #11 V2.20 standard, that the output from CKM_RSA_PKCS should always be padded. I am puzzled why PADDING defaults to 0, but I am scared to blindly flip it to 1 and break some other use cases. For this reason I preffered to add an option.

Let me know if this patch needs rework. For example, I evaluated to have the has_padding option per-provider. However, I couldn't understand how the provider is selected when answering to a gpg-agent command. I guess I need to look into pkcs11-helper for that, any pointer would be appreciated.

Thanks!