### PR TITLE
gnupg-pkcs11-scd: add PKAUTH command support

### DIFF
--- a/gnupg-pkcs11-scd/command.h
+++ b/gnupg-pkcs11-scd/command.h
@@ -49,6 +49,7 @@ gpg_error_t cmd_readcert (assuan_context_t ctx, char *line);
 gpg_error_t cmd_readkey (assuan_context_t ctx, char *line);
 gpg_error_t cmd_setdata (assuan_context_t ctx, char *line);
 gpg_error_t cmd_pksign (assuan_context_t ctx, char *line);
+gpg_error_t cmd_pkauth (assuan_context_t ctx, char *line);
 gpg_error_t cmd_pkdecrypt (assuan_context_t ctx, char *line);
 gpg_error_t cmd_random (assuan_context_t ctx, char *line);
 gpg_error_t cmd_checkpin (assuan_context_t ctx, char *line);

--- a/gnupg-pkcs11-scd/scdaemon.c
+++ b/gnupg-pkcs11-scd/scdaemon.c
@@ -125,7 +125,7 @@ register_commands (const assuan_context_t ctx)
 		{ "KEY-DATA",	NULL, NULL },
 		{ "SETDATA",	cmd_setdata, NULL },
 		{ "PKSIGN",	cmd_pksign, NULL },
-		{ "PKAUTH",	NULL, NULL },
+		{ "PKAUTH",	cmd_pkauth, NULL },
 		{ "PKDECRYPT",	cmd_pkdecrypt, NULL },
 		{ "INPUT",	NULL, NULL }, 
 		{ "OUTPUT",	NULL, NULL }, 


### PR DESCRIPTION
This commit adds PKAUTH command support to gnupg-pkcs11-scd, so
gpg-agent with "enable-ssh-support" setting defined can act as a SSH
Agent when PKCS11 is used as a GPG backend.

Auth operation is almost the same as sign operation, except it looks
like SSH always sends data with hash algorithm signature appended at the
beginning, but the data is of different size than the signature
detection code expects, so it always fallback to default behavior, which
is to append SHA1 signature.

As having 2 different signature prefixes is incorrect, we need to
use the different default value from the sign action, which is to not
append anything in case of auth operation.

Closes #27

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>