### PR TITLE
gnupg-pkcs11-scd/command.c: fix segfault on PKAUTH command

### DIFF
--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1132,7 +1132,7 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 	/*
 	 * sender prefixed data with algorithm OID
 	 */
-	if (strcmp(hash, "")) {
+	if (hash != NULL && strcmp(hash, "")) {
 		if (!strcmp(hash, "rmd160") && data->size == (0x14 + sizeof(rmd160_prefix)) &&
 			!memcmp (data->data, rmd160_prefix, sizeof (rmd160_prefix))) {
 			inject = INJECT_NONE;


### PR DESCRIPTION
It seems hash value is no longer an empty string but a null pointer, so
the condition must handle it, otherwise it segfaults.

Closes #39

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>