### PR TITLE
Support EcDSA Keys with Named Curves

### DIFF
--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1112,23 +1112,23 @@ cleanup:
 
 static CK_RV _pkcs11_keyinfo_mechanism(keyinfo keyinfo, CK_MECHANISM_TYPE_PTR pkcs11_mechanism) {
 	if (keyinfo == NULL) {
-		return(CKR_ARGUMENTS_BAD);
+		return CKR_ARGUMENTS_BAD;
 	}
 
 	switch (keyinfo_get_type(keyinfo)) {
 		case KEYINFO_KEY_TYPE_RSA:
 			*pkcs11_mechanism = CKM_RSA_PKCS;
-			return(CKR_OK);
+			return CKR_OK;
 		case KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE:
 			*pkcs11_mechanism = CKM_ECDSA;
-			return(CKR_OK);
+			return CKR_OK;
 		case KEYINFO_KEY_TYPE_UNKNOWN:
-			return(CKR_GENERAL_ERROR);
+			return CKR_GENERAL_ERROR;
 		case KEYINFO_KEY_TYPE_INVALID:
-			abort();
+			return CKR_GENERAL_ERROR;
 	}
 
-	return(CKR_GENERAL_ERROR);
+	return CKR_GENERAL_ERROR;
 }
 
 struct prefix_pkcs1 {

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -496,6 +496,7 @@ send_certificate_list (
 
 		if (sexp != NULL) {
 			gcry_sexp_release (sexp);
+			sexp = NULL;
 		}
 
 		if (info_cert != NULL) {

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1774,6 +1774,10 @@ gpg_error_t cmd_keyinfo (assuan_context_t ctx, char *line)
 		error = GPG_ERR_NO_ERROR;
 
 	retry:
+		if (sexp != NULL) {
+			gcry_free (sexp);
+			sexp = NULL;
+		}
 
 		if (keyinfo_line != NULL) {
 			free (keyinfo_line);

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1637,7 +1637,7 @@ gpg_error_t cmd_pkdecrypt (assuan_context_t ctx, char *line)
 		(error = common_map_pkcs11_error (
 			pkcs11h_certificate_decryptAny (
 				cert,
-				CKM_RSA_PKCS,
+				CKM_RSA_PKCS, 
 				_data.data,
 				_data.size,
 				NULL,

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1131,35 +1131,97 @@ static CK_RV _pkcs11_keyinfo_mechanism(keyinfo keyinfo, CK_MECHANISM_TYPE_PTR pk
 	return(CKR_GENERAL_ERROR);
 }
 
+struct prefix_pkcs1 {
+	const char *const name;
+	const unsigned char der[32];
+	const unsigned int der_size;
+	const unsigned int hash_size;
+};
+static struct prefix_pkcs1 prefix_pkcs1_list[] = {
+	{
+		.name = "rmd160",
+		.der = {
+			/* (1.3.36.3.2.1) */
+			0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x24, 0x03,
+			0x02, 0x01, 0x05, 0x00, 0x04, 0x14
+		},
+		.der_size = 15,
+		.hash_size = 20
+	},
+	{
+		.name = "md5",
+		.der = {
+			/* (1.2.840.113549.2.5) */
+			0x30, 0x2c, 0x30, 0x09, 0x06, 0x08, 0x2a, 0x86, 0x48,
+			0x86, 0xf7, 0x0d, 0x02, 0x05, 0x05, 0x00, 0x04, 0x10
+		},
+		.der_size = 18,
+		.hash_size = 16
+	},
+	{
+		.name = "sha1",
+		.der = {
+			/* (1.3.14.3.2.26) */
+			0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03,
+			0x02, 0x1a, 0x05, 0x00, 0x04, 0x14
+		},
+		.der_size = 15,
+		.hash_size = 20
+	},
+	{
+		.name = "sha224",
+		.der = {
+			/* (2.16.840.1.101.3.4.2.4) */
+			0x30, 0x2D, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48,
+			0x01, 0x65, 0x03, 0x04, 0x02, 0x04, 0x05, 0x00, 0x04,
+			0x1C
+		},
+		.der_size = 19,
+		.hash_size = 28
+	},
+	{
+		.name = "sha256",
+		.der = {
+			/* (2.16.840.1.101.3.4.2.1) */
+			0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48,
+			0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04,
+			0x20
+		},
+		.der_size = 19,
+		.hash_size = 32
+	},
+	{
+		.name = "sha384",
+		.der = {
+			/* (2.16.840.1.101.3.4.2.2) */
+			0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48,
+			0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0x04,
+			0x30
+		},
+		.der_size = 19,
+		.hash_size = 48
+	},
+	{
+		.name = "sha512",
+		.der = {
+			/* (2.16.840.1.101.3.4.2.3) */
+			0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48,
+			0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04,
+			0x40
+		},
+		.der_size = 19,
+		.hash_size = 64
+	},
+	{
+		.name = NULL,
+		.der_size = 0,
+		.hash_size = 0
+	}
+};
+
 static
 gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 {
-	static const unsigned char rmd160_prefix_pkcs1[] = /* (1.3.36.3.2.1) */
-		{ 0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x24, 0x03,
-		0x02, 0x01, 0x05, 0x00, 0x04, 0x14  };
-	static const unsigned char md5_prefix_pkcs1[] =   /* (1.2.840.113549.2.5) */
-		{ 0x30, 0x2c, 0x30, 0x09, 0x06, 0x08, 0x2a, 0x86, 0x48,
-		0x86, 0xf7, 0x0d, 0x02, 0x05, 0x05, 0x00, 0x04, 0x10  };
-	static const unsigned char sha1_prefix_pkcs1[] =   /* (1.3.14.3.2.26) */
-		{ 0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03,
-		0x02, 0x1a, 0x05, 0x00, 0x04, 0x14  };
-	static const unsigned char sha224_prefix_pkcs1[] = /* (2.16.840.1.101.3.4.2.4) */
-		{ 0x30, 0x2D, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48,
-		0x01, 0x65, 0x03, 0x04, 0x02, 0x04, 0x05, 0x00, 0x04,
-		0x1C  };
-	static const unsigned char sha256_prefix_pkcs1[] = /* (2.16.840.1.101.3.4.2.1) */
-		{ 0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
-		0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05,
-		0x00, 0x04, 0x20  };
-	static const unsigned char sha384_prefix_pkcs1[] = /* (2.16.840.1.101.3.4.2.2) */
-		{ 0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
-		0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05,
-		0x00, 0x04, 0x30  };
-	static const unsigned char sha512_prefix_pkcs1[] = /* (2.16.840.1.101.3.4.2.3) */
-		{ 0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
-		0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,
-		0x00, 0x04, 0x40  };
-
 	gpg_err_code_t error = GPG_ERR_GENERAL;
 	pkcs11h_certificate_id_t cert_id = NULL;
 	pkcs11h_certificate_t cert = NULL;
@@ -1170,20 +1232,12 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 	keyinfo keyinfo = NULL;
 	unsigned char *sig = NULL;
 	size_t sig_len;
-	ssize_t data_effective_len;
-	enum {
-		INJECT_NONE,
-		INJECT_RMD160,
-		INJECT_MD5,
-		INJECT_SHA1,
-		INJECT_SHA224,
-		INJECT_SHA256,
-		INJECT_SHA384,
-		INJECT_SHA512
-	} inject = INJECT_NONE;
+	struct prefix_pkcs1 *inject = NULL;
+	ssize_t data_effective_len, data_offset = 0;
 	CK_MECHANISM_TYPE pkcs11_mechanism;
 	int use_pkcs1;
 	char *hash = NULL;
+	int found_hash_algo = 0;
 	const char *l;
 	const struct strgetopt_option options[] = {
 		{"hash", strgtopt_required_argument, &hash, NULL},
@@ -1242,133 +1296,126 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 		/*
 		 * sender prefixed data with algorithm OID
 		 */
-		if (hash != NULL) {
-			if (!strcmp(hash, "rmd160") && data->size == (0x14 + sizeof(rmd160_prefix_pkcs1)) &&
-				!memcmp (data->data, rmd160_prefix_pkcs1, sizeof (rmd160_prefix_pkcs1))) {
-				inject = INJECT_NONE;
+		for (struct prefix_pkcs1 *prefix_pkcs1_check = prefix_pkcs1_list; prefix_pkcs1_check->name != NULL; prefix_pkcs1_check++) {
+			if (hash != NULL) {
+				if (strcmp(hash, prefix_pkcs1_check->name)) {
+					continue;
+				}
+
+				if (data->size == prefix_pkcs1_check->hash_size) {
+					inject = prefix_pkcs1_check;
+
+					found_hash_algo = 1;
+
+					break;
+				}
 			}
-			else if (!strcmp(hash, "rmd160") && data->size == 0x14) {
-				inject = INJECT_RMD160;
+
+			if (data->size == (prefix_pkcs1_check->hash_size + prefix_pkcs1_check->der_size) &&
+				!memcmp (data->data, prefix_pkcs1_check->der, prefix_pkcs1_check->der_size)) {
+
+				inject = NULL;
+
+				found_hash_algo = 1;
+
+				break;
 			}
-			else if (!strcmp(hash, "md5") && data->size == (0x10 + sizeof(md5_prefix_pkcs1)) &&
-				!memcmp (data->data, md5_prefix_pkcs1, sizeof (md5_prefix_pkcs1))) {
-				inject = INJECT_NONE;
-			}
-			else if (!strcmp(hash, "md5") && data->size == 0x10) {
-				inject = INJECT_MD5;
-			}
-			else if (!strcmp(hash, "sha1") && data->size == (0x14 + sizeof(sha1_prefix_pkcs1)) &&
-				!memcmp (data->data, sha1_prefix_pkcs1, sizeof (sha1_prefix_pkcs1))) {
-				inject = INJECT_NONE;
-			}
-			else if (!strcmp(hash, "sha1") && data->size == 0x14) {
-				inject = INJECT_SHA1;
-			}
-			else if (!strcmp(hash, "sha224") && data->size == (0x1c + sizeof(sha224_prefix_pkcs1)) &&
-				!memcmp (data->data, sha224_prefix_pkcs1, sizeof (sha224_prefix_pkcs1))) {
-				inject = INJECT_NONE;
-			}
-			else if (!strcmp(hash, "sha224") && data->size == 0x1c) {
-				inject = INJECT_SHA224;
-			}
-			else if (!strcmp(hash, "sha256") && data->size == (0x20 + sizeof(sha256_prefix_pkcs1)) &&
-				!memcmp (data->data, sha256_prefix_pkcs1, sizeof (sha256_prefix_pkcs1))) {
-				inject = INJECT_NONE;
-			}
-			else if (!strcmp(hash, "sha256") && data->size == 0x20) {
-				inject = INJECT_SHA256;
-			}
-			else if (!strcmp(hash, "sha384") && data->size == (0x30 + sizeof(sha384_prefix_pkcs1)) &&
-				!memcmp (data->data, sha384_prefix_pkcs1, sizeof (sha384_prefix_pkcs1))) {
-				inject = INJECT_NONE;
-			}
-			else if (!strcmp(hash, "sha384") && data->size == 0x30) {
-				inject = INJECT_SHA384;
-			}
-			else if (!strcmp(hash, "sha512") && data->size == (0x40 + sizeof(sha512_prefix_pkcs1)) &&
-				!memcmp (data->data, sha512_prefix_pkcs1, sizeof (sha512_prefix_pkcs1))) {
-				inject = INJECT_NONE;
-			}
-			else if (!strcmp(hash, "sha512") && data->size == 0x40) {
-				inject = INJECT_SHA512;
-			}
-			else {
+		}
+
+		if (!found_hash_algo) {
+			/*
+			 * If a hash algorithm was specified and it was not
+			 * found, return in failure
+			 */
+			if (hash != NULL) {
 				common_log (LOG_DEBUG, "unsupported hash algo (hash=%s,size=%d)", hash, data->size);
 				error = GPG_ERR_UNSUPPORTED_ALGORITHM;
 				goto cleanup;
 			}
-		}
-		else {
-			if (
-				data->size == 0x10 + sizeof (md5_prefix_pkcs1) ||
-				data->size == 0x14 + sizeof (sha1_prefix_pkcs1) ||
-				data->size == 0x14 + sizeof (rmd160_prefix_pkcs1)
-			) {
-				if (
-					memcmp (data->data, md5_prefix_pkcs1, sizeof (md5_prefix_pkcs1)) &&
-					memcmp (data->data, sha1_prefix_pkcs1, sizeof (sha1_prefix_pkcs1)) &&
-					memcmp (data->data, rmd160_prefix_pkcs1, sizeof (rmd160_prefix_pkcs1))
-				) {
-					error = GPG_ERR_UNSUPPORTED_ALGORITHM;
-					goto cleanup;
+
+			/*
+			 * unknown hash algorithm;
+			 * gnupg's scdaemon forces to SHA1
+			 */
+			for (struct prefix_pkcs1 *prefix_pkcs1_check = prefix_pkcs1_list; prefix_pkcs1_check->name != NULL; prefix_pkcs1_check++) {
+				if (!strcmp(prefix_pkcs1_check->name, "sha1")) {
+					inject = prefix_pkcs1_check;
+
+					break;
 				}
 			}
-			else {
-				/*
-				 * unknown hash algorithm;
-				 * gnupg's scdaemon forces to SHA1
-				 */
-				inject = INJECT_SHA1;
 
-				/* When doing auth operation, hash algorithm prefix detection does not work
-				 * but data always comes with algorithm appended, so do not append anything
-				 * by default. */
-				if (typehint == OPENPGP_AUTH) {
-					inject = INJECT_NONE;
-				}
+			/* When doing auth operation, hash algorithm prefix detection does not work
+			 * but data always comes with algorithm appended, so do not append anything
+			 * by default. */
+			if (typehint == OPENPGP_AUTH) {
+				inject = NULL;
 			}
 		}
 	} else {
-		/* Non-PKCS1 does not inject anything */
-		inject = INJECT_NONE;
+		/* Non-PKCS1 does not inject anything, but may need to remove wrapping */
+		inject = NULL;
+
+		/* Remove any existing PKCS1 prefix from to-be-signed data */
+		for (struct prefix_pkcs1 *prefix_pkcs1_check = prefix_pkcs1_list; prefix_pkcs1_check->name != NULL; prefix_pkcs1_check++) {
+			if (hash != NULL) {
+				if (strcmp(hash, prefix_pkcs1_check->name)) {
+					continue;
+				}
+
+				if (data->size == prefix_pkcs1_check->hash_size) {
+					data_offset = 0;
+
+					found_hash_algo = 1;
+
+					break;
+				}
+			}
+
+			if (data->size == (prefix_pkcs1_check->hash_size + prefix_pkcs1_check->der_size) &&
+				!memcmp (data->data, prefix_pkcs1_check->der, prefix_pkcs1_check->der_size)) {
+
+				data_offset = prefix_pkcs1_check->der_size;
+
+				found_hash_algo = 1;
+
+				break;
+			}
+		}
+
+		if (!found_hash_algo) {
+			common_log (LOG_DEBUG, "unsupported hash algo (hash=%s,size=%d)", hash, data->size);
+			error = GPG_ERR_UNSUPPORTED_ALGORITHM;
+			goto cleanup;
+		}
+
+		if (data_offset > 0) {
+			if (data_offset > _data->size) {
+				error = GPG_ERR_TRUNCATED;
+				goto cleanup;
+			}
+
+			need_free__data = 1;
+
+			if ((_data = (cmd_data_t *)malloc (sizeof (cmd_data_t))) == NULL) {
+				error = GPG_ERR_ENOMEM;
+				goto cleanup;
+			}
+
+			_data->size = data->size - data_offset;
+			if ((_data->data = (unsigned char *)malloc (_data->size)) == NULL) {
+				error = GPG_ERR_ENOMEM;
+				goto cleanup;
+			}
+
+			memcpy(_data->data, data->data + data_offset, _data->size);
+			data_offset = 0;
+		}
 	}
 
-	if (inject != INJECT_NONE) {
-		const unsigned char *oid;
-		size_t oid_size;
-		switch (inject) {
-			case INJECT_RMD160:
-				oid = rmd160_prefix_pkcs1;
-				oid_size = sizeof (rmd160_prefix_pkcs1);
-			break;
-			case INJECT_MD5:
-				oid = md5_prefix_pkcs1;
-				oid_size = sizeof (md5_prefix_pkcs1);
-			break;
-			case INJECT_SHA1:
-				oid = sha1_prefix_pkcs1;
-				oid_size = sizeof (sha1_prefix_pkcs1);
-			break;
-			case INJECT_SHA224:
-				oid = sha224_prefix_pkcs1;
-				oid_size = sizeof (sha224_prefix_pkcs1);
-			break;
-			case INJECT_SHA256:
-				oid = sha256_prefix_pkcs1;
-				oid_size = sizeof(sha256_prefix_pkcs1);
-			break;
-			case INJECT_SHA384:
-				oid = sha384_prefix_pkcs1;
-				oid_size = sizeof(sha384_prefix_pkcs1);
-			break;
-			case INJECT_SHA512:
-				oid = sha512_prefix_pkcs1;
-				oid_size = sizeof(sha512_prefix_pkcs1);
-			break;
-			default:
-				error = GPG_ERR_INV_DATA;
-				goto cleanup;
-		}
+	if (inject != NULL) {
+		const unsigned char *oid = inject->der;
+		size_t oid_size = inject->der_size;
 
 		need_free__data = 1;
 
@@ -1405,6 +1452,7 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 
 	data_effective_len = keyinfo_get_data_length(keyinfo, _data->size);
 	if (data_effective_len < 0) {
+		error = GPG_ERR_TRUNCATED;
 		goto cleanup;
 	}
 
@@ -1483,10 +1531,12 @@ cleanup:
 	}
 
 	if (need_free__data) {
-		free (_data->data);
-		_data->data = NULL;
-		free (_data);
-		_data = NULL;
+		if (_data != NULL) {
+			free (_data->data);
+			_data->data = NULL;
+			free (_data);
+			_data = NULL;
+		}
 	}
 
 	strgetopt_free(options);

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -487,6 +487,10 @@ send_certificate_list (
 
 	retry:
 
+		if (sexp != NULL) {
+			gcry_sexp_release (sexp);
+		}
+
 		if (info_cert != NULL) {
 			free (info_cert);
 			info_cert = NULL;

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1233,7 +1233,8 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 	unsigned char *sig = NULL;
 	size_t sig_len;
 	struct prefix_pkcs1 *inject = NULL;
-	ssize_t data_effective_len, data_offset = 0;
+	ssize_t data_effective_len;
+	size_t data_offset = 0;
 	CK_MECHANISM_TYPE pkcs11_mechanism;
 	int use_pkcs1;
 	char *hash = NULL;

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1170,6 +1170,7 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 	keyinfo keyinfo = NULL;
 	unsigned char *sig = NULL;
 	size_t sig_len;
+	ssize_t data_effective_len;
 	enum {
 		INJECT_NONE,
 		INJECT_RMD160,
@@ -1402,6 +1403,11 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 		goto cleanup;
 	}
 
+	data_effective_len = keyinfo_get_data_length(keyinfo, _data->size);
+	if (data_effective_len < 0) {
+		goto cleanup;
+	}
+
 	if (
 		(error = common_map_pkcs11_error (
 			pkcs11h_certificate_lockSession (cert)
@@ -1417,7 +1423,7 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 				cert,
 				pkcs11_mechanism,
 				_data->data,
-				_data->size,
+				data_effective_len,
 				NULL,
 				&sig_len
 			)
@@ -1437,7 +1443,7 @@ gpg_error_t _cmd_pksign_type (assuan_context_t ctx, char *line, int typehint)
 				cert,
 				pkcs11_mechanism,
 				_data->data,
-				_data->size,
+				data_effective_len,
 				sig,
 				&sig_len
 			)

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1979,7 +1979,7 @@ gpg_error_t cmd_genkey (assuan_context_t ctx, char *line)
 	gpg_err_code_t error = GPG_ERR_GENERAL;
 	pkcs11h_certificate_id_t cert_id = NULL;
 	keyinfo keyinfo;
-	keyinfo_data_list key_parts, curr_key_part;
+	keyinfo_data_list key_parts = NULL, curr_key_part;
 	unsigned char *n_hex = NULL;
 	unsigned char *e_hex = NULL;
 	char *part_resp = NULL;

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -2007,7 +2007,7 @@ gpg_error_t cmd_genkey (assuan_context_t ctx, char *line)
 
 	if (timestamp == NULL) {
 		sprintf (_timestamp, "%d", (int)time (NULL));
-		timestamp = _timestamp;
+		timestamp = strdup(_timestamp);
 	}
 
 	if (

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -35,6 +35,7 @@
 #if defined(ENABLE_OPENSSL)
 #include <openssl/x509.h>
 #include <openssl/rsa.h>
+#include <openssl/evp.h>
 #endif
 #include "encoding.h"
 #include "keyutil.h"
@@ -249,11 +250,11 @@ keyinfo_from_der(
 		goto cleanup;
 	}
 
-	if (EVP_PKEY_CTX_is_a(pubkey_ctx, "EC") == 1) {
+	if (EVP_PKEY_get_base_id(pubkey) == EVP_PKEY_EC) {
 		keyinfo_init(keyinfo, KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE);
 	}
 
-	if (EVP_PKEY_CTX_is_a(pubkey_ctx, "RSA") == 1) {
+	if (EVP_PKEY_get_base_id(pubkey) == EVP_PKEY_RSA) {
 		keyinfo_init(keyinfo, KEYINFO_KEY_TYPE_RSA);
 	}
 

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -353,7 +353,7 @@ keyinfo_from_der(
 			error = GPG_ERR_NO_ERROR;
 			break;
 		case KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE:
-			keyinfo->data.ecdsa.named_curve = "prime256v1"; /* XXX:TODO */
+			keyinfo->data.ecdsa.named_curve = "NIST P-256"; /* XXX:TODO */
 			keyinfo->data.ecdsa.named_curve_free = 0;
 
 			keyinfo->data.ecdsa.q = q_mpi;
@@ -577,9 +577,7 @@ struct curve_info_map_s {
 static struct curve_info_map_s curve_info_map[] = {
 	/* secp256r1 */
 	{"NIST P-256", "082A8648CE3D030107"},
-	{"secp256r1", "082A8648CE3D030107"},
 	{"nistp256", "082A8648CE3D030107"},
-	{"prime256v1", "082A8648CE3D030107"},
 	{"1.2.840.10045.3.1.7", "082A8648CE3D030107"},
 
 	/* secp256k1 */

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -46,6 +46,58 @@ typedef unsigned char *my_openssl_d2i_t;
 typedef const unsigned char *my_openssl_d2i_t;
 #endif
 
+/**
+ * Initialize a KeyUtil KeyInfo Object
+ */
+void keyutil_keyinfo_init(keyutil_keyinfo_t *keyinfo, keyutil_key_type_t keytype) {
+	keyinfo->type = keytype;
+
+	if (keyinfo->type == KEYUTIL_KEY_TYPE_RSA || keyinfo->type == KEYUTIL_KEY_TYPE_UNKNOWN) {
+		keyinfo->data.rsa.e = NULL;
+		keyinfo->data.rsa.n = NULL;
+	}
+
+	if (keyinfo->type == KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE || keyinfo->type == KEYUTIL_KEY_TYPE_UNKNOWN) {
+		keyinfo->data.ecdsa.q = NULL;
+		keyinfo->data.ecdsa.named_curve = NULL;
+		keyinfo->data.ecdsa.named_curve_free = 0;
+	}
+}
+
+/**
+ * Free any resources held by a KeyUtil KeyInfo object.
+ * Does not release the KeyInfo object itself (which may be stack allocated)
+ */
+void keyutil_keyinfo_free(keyutil_keyinfo_t *keyinfo) {
+	switch (keyinfo->type) {
+		case KEYUTIL_KEY_TYPE_RSA:
+			if (keyinfo->data.rsa.e) {
+				gcry_mpi_release(keyinfo->data.rsa.e);
+				keyinfo->data.rsa.e = NULL;
+			}
+			if (keyinfo->data.rsa.n) {
+				gcry_mpi_release(keyinfo->data.rsa.n);
+				keyinfo->data.rsa.n = NULL;
+			}
+			break;
+		case KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE:
+			if (keyinfo->data.ecdsa.q) {
+				gcry_mpi_release(keyinfo->data.ecdsa.q);
+				keyinfo->data.ecdsa.q = NULL;
+			}
+			if (keyinfo->data.ecdsa.named_curve) {
+				if (keyinfo->data.ecdsa.named_curve_free) {
+					free(keyinfo->data.ecdsa.named_curve);
+				}
+				keyinfo->data.ecdsa.named_curve = NULL;
+			}
+			break;
+		case KEYUTIL_KEY_TYPE_UNKNOWN:
+			/* Nothing to do for unknown types */
+			break;
+	}
+}
+
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d) {
 	if (n != NULL) {
@@ -66,26 +118,29 @@ gpg_err_code_t
 keyutil_get_cert_mpi (
 	unsigned char *der,
 	size_t len,
-	gcry_mpi_t *p_n_mpi,
-	gcry_mpi_t *p_e_mpi
+	keyutil_keyinfo_t *keyinfo
 ) {
 	gpg_err_code_t error = GPG_ERR_GENERAL;
 	gcry_mpi_t n_mpi = NULL;
 	gcry_mpi_t e_mpi = NULL;
+	gcry_mpi_t q_mpi = NULL;
 #if defined(ENABLE_GNUTLS)
 	gnutls_x509_crt_t cert = NULL;
 	gnutls_datum_t datum = {der, len};
 	gnutls_datum_t m = {NULL, 0}, e = {NULL, 0};
 #elif defined(ENABLE_OPENSSL)
+	int check_result;
 	X509 *x509 = NULL;
 	EVP_PKEY *pubkey = NULL;
+	EVP_PKEY_CTX *pubkey_ctx = NULL;
 	RSA *rsa = NULL;
+	EC_KEY *ec_key = NULL;
+	EC_POINT *ec_pubkey;
+	EC_GROUP *ec_group;
 	const BIGNUM *n, *e;
-	char *n_hex = NULL, *e_hex = NULL;
+	BN_CTX *q_ctx = NULL;
+	char *n_hex = NULL, *e_hex = NULL, *q_hex = NULL;
 #endif
-
-	*p_n_mpi = NULL;
-	*p_e_mpi = NULL;
 
 #if defined(ENABLE_GNUTLS)
 	if (gnutls_x509_crt_init (&cert) != GNUTLS_E_SUCCESS) {
@@ -118,43 +173,138 @@ keyutil_get_cert_mpi (
 		error = GPG_ERR_BAD_CERT;
 		goto cleanup;
 	}
- 
+
 	if ((pubkey = X509_get_pubkey (x509)) == NULL) {
 		error = GPG_ERR_BAD_CERT;
 		goto cleanup;
 	}
- 
-	if ((rsa = EVP_PKEY_get1_RSA(pubkey)) == NULL) {
+
+	pubkey_ctx = EVP_PKEY_CTX_new(pubkey, NULL);
+	if (pubkey_ctx == NULL) {
+fprintf(stderr, "Can't create PUBKEY_CTX\n");
+		error = GPG_ERR_BAD_CERT;
+		goto cleanup;
+	}
+
+	/**
+	 * Check the public key context
+	 * 1 is success, -2 is not applicable
+	 */
+	check_result = EVP_PKEY_public_check(pubkey_ctx);
+	if (check_result != 1 && check_result != -2) {
+fprintf(stderr, "Can't check PUBKEY_CTX\n");
 		error = GPG_ERR_WRONG_PUBKEY_ALGO;
 		goto cleanup;
 	}
 
-	RSA_get0_key(rsa, &n, &e, NULL);
-
-	n_hex = BN_bn2hex (n);
-	e_hex = BN_bn2hex (e);
-
-	if(n_hex == NULL || e_hex == NULL) {
-		error = GPG_ERR_BAD_KEY;
-		goto cleanup;
+	if (EVP_PKEY_CTX_is_a(pubkey_ctx, "EC") == 1) {
+		keyutil_keyinfo_init(keyinfo, KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE);
 	}
+
+	if (EVP_PKEY_CTX_is_a(pubkey_ctx, "RSA") == 1) {
+		keyutil_keyinfo_init(keyinfo, KEYUTIL_KEY_TYPE_RSA);
+	}
+
+	switch (keyinfo->type) {
+		case KEYUTIL_KEY_TYPE_RSA:
+			/* Warning: EVP_PKEY_get1_RSA is deprecated in OpenSSL 3.0 */ 
+			if ((rsa = EVP_PKEY_get1_RSA(pubkey)) == NULL) {
+				error = GPG_ERR_WRONG_PUBKEY_ALGO;
+				goto cleanup;
+			}
+
+			RSA_get0_key(rsa, &n, &e, NULL);
+
+			n_hex = BN_bn2hex (n);
+			e_hex = BN_bn2hex (e);
+
+			if(n_hex == NULL || e_hex == NULL) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
  
-	if (
-		gcry_mpi_scan (&n_mpi, GCRYMPI_FMT_HEX, n_hex, 0, NULL) ||
-		gcry_mpi_scan (&e_mpi, GCRYMPI_FMT_HEX, e_hex, 0, NULL)
-	) {
-		error = GPG_ERR_BAD_KEY;
-		goto cleanup;
+			if (
+				gcry_mpi_scan (&n_mpi, GCRYMPI_FMT_HEX, n_hex, 0, NULL) ||
+				gcry_mpi_scan (&e_mpi, GCRYMPI_FMT_HEX, e_hex, 0, NULL)
+			) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+			break;
+		case KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE:
+			/* Warning: EVP_PKEY_get1_EC_KEY is depreacted in OpenSSL 3.0 */
+			ec_key = EVP_PKEY_get1_EC_KEY(pubkey);
+			if (ec_key == NULL) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+
+			/* Warning: EC_KEY_get0_public_key is depreacted in OpenSSL 3.0 */
+			ec_pubkey = EC_KEY_get0_public_key(ec_key);
+			if (ec_pubkey == NULL) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+
+			/* Warning: EC_KEY_get0_group is depreacted in OpenSSL 3.0 */
+			ec_group = EC_KEY_get0_group(ec_key);
+			if (ec_group == NULL) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+
+			q_ctx = BN_CTX_new();
+			if (q_ctx == NULL) {
+				error = GPG_ERR_SYSTEM_ERROR;
+				goto cleanup;
+			}
+
+			q_hex = EC_POINT_point2hex(ec_group, ec_pubkey, EC_GROUP_get_point_conversion_form(ec_group), q_ctx);
+			BN_CTX_free(q_ctx);
+
+			if (q_hex == NULL) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+
+			if (gcry_mpi_scan (&q_mpi, GCRYMPI_FMT_HEX, q_hex, 0, NULL)) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+			break;
+		case KEYUTIL_KEY_TYPE_UNKNOWN:
+			error = GPG_ERR_BAD_KEY;
+			goto cleanup;
 	}
 #else
 #error Invalid configuration.
 #endif
 
-	*p_n_mpi = n_mpi;
-	n_mpi = NULL;
-	*p_e_mpi = e_mpi;
-	e_mpi = NULL;
-	error = GPG_ERR_NO_ERROR;
+	switch (keyinfo->type) {
+		case KEYUTIL_KEY_TYPE_RSA:
+			keyinfo->data.rsa.n = n_mpi;
+			n_mpi = NULL;
+
+			keyinfo->data.rsa.e = e_mpi;
+			e_mpi = NULL;
+
+			error = GPG_ERR_NO_ERROR;
+			break;
+		case KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE:
+			keyinfo->data.ecdsa.named_curve = "prime256v1"; /* XXX:TODO */
+			keyinfo->data.ecdsa.named_curve_free = 0;
+
+			keyinfo->data.ecdsa.q = q_mpi;
+			q_mpi = NULL;
+
+			error = GPG_ERR_NO_ERROR;
+			break;
+		case KEYUTIL_KEY_TYPE_UNKNOWN:
+fprintf(stderr, "Can't identify pubkey [2]\n");
+			error = GPG_ERR_BAD_KEY;
+			goto cleanup;
+			break;
+	}
 
 cleanup:
 
@@ -166,6 +316,11 @@ cleanup:
 	if (e_mpi != NULL) {
 		gcry_mpi_release (e_mpi);
 		e_mpi = NULL;
+	}
+
+	if (q_mpi != NULL) {
+		gcry_mpi_release (q_mpi);
+		q_mpi = NULL;
 	}
 
 #if defined(ENABLE_GNUTLS)
@@ -192,14 +347,26 @@ cleanup:
 		x509 = NULL;
 	}
 
+	if (pubkey_ctx) {
+		EVP_PKEY_CTX_free(pubkey_ctx);
+		pubkey_ctx = NULL;
+	}
+
 	if (pubkey != NULL) {
 		EVP_PKEY_free(pubkey);
 		pubkey = NULL;
 	}
 
 	if (rsa != NULL) {
+		/* Warning: RSA_free is deprecated in OpenSSL 3.0 */
 		RSA_free(rsa);
 		rsa = NULL;
+	}
+
+	if (ec_key != NULL) {
+		/* Warning: EC_KEY_free is deprecated in OpenSSL 3.0 */
+		EC_KEY_free(ec_key);
+		ec_key = NULL;
 	}
 
 	if (n_hex != NULL) {
@@ -212,17 +379,23 @@ cleanup:
 		e_hex = NULL;
 	}
 
+	if (q_hex != NULL) {
+		OPENSSL_free (q_hex);
+		q_hex = NULL;
+	}
+
 #else
 #error Invalid configuration.
 #endif
 
 	return error;
 }
+
 /**
-   Convert X.509 RSA public key into gcrypt internal sexp form. Only RSA
-   public keys are accepted at the moment. The result is stored in *sexp,
-   which must be freed (using ) when not needed anymore. *sexp must be
-   NULL on entry, since it is overwritten.
+   Convert the public key from an X.509 certificate into gcrypt internal
+   sexp form.  The result is stored in *sexp, which must be freed (using
+   gcry_sexp_release) when not needed anymore. *sexp must be NULL on
+   entry, since it is overwritten.
 */
 gpg_err_code_t
 keyutil_get_cert_sexp (
@@ -231,30 +404,48 @@ keyutil_get_cert_sexp (
 	gcry_sexp_t *p_sexp
 ) {
 	gpg_err_code_t error = GPG_ERR_GENERAL;
-	gcry_mpi_t n_mpi = NULL;
-	gcry_mpi_t e_mpi = NULL;
+	keyutil_keyinfo_t keyinfo;
 	gcry_sexp_t sexp = NULL;
+	gcry_error_t sexp_build_result;
 
-	if (
-		(error = keyutil_get_cert_mpi (
-			der,
-			len,
-			&n_mpi,
-			&e_mpi
-		)) != GPG_ERR_NO_ERROR
-	) {
+	keyutil_keyinfo_init(&keyinfo, KEYUTIL_KEY_TYPE_UNKNOWN);
+
+	fprintf(stderr, "der = %p (len = %lli)\n", der, (unsigned long long) len);
+	error = keyutil_get_cert_mpi (
+		der,
+		len,
+		&keyinfo
+	);
+
+	if (error != GPG_ERR_NO_ERROR) {
 		goto cleanup;
 	}
 
-	if (
-		gcry_sexp_build (
-			&sexp,
-			NULL,
-			"(public-key (rsa (n %m) (e %m)))",
-			n_mpi,
-			e_mpi
-		)
-	) {
+	switch (keyinfo.type) {
+		case KEYUTIL_KEY_TYPE_RSA:
+			sexp_build_result = gcry_sexp_build(
+				&sexp,
+				NULL,
+				"(public-key (rsa (n %m) (e %m)))",
+				keyinfo.data.rsa.n,
+				keyinfo.data.rsa.e
+			);
+			break;
+		case KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE:
+			sexp_build_result = gcry_sexp_build(
+				&sexp,
+				NULL,
+				"(public-key (ecc (curve %s) (q %m)))",
+				keyinfo.data.ecdsa.named_curve,
+				keyinfo.data.ecdsa.q
+			);
+			break;
+		case KEYUTIL_KEY_TYPE_UNKNOWN:
+			sexp_build_result = 1;
+			break;
+	}
+
+	if (sexp_build_result != 0) {
 		error = GPG_ERR_BAD_KEY;
 		goto cleanup;
 	}
@@ -265,15 +456,7 @@ keyutil_get_cert_sexp (
 
 cleanup:
 
-	if (n_mpi != NULL) {
-		gcry_mpi_release (n_mpi);
-		n_mpi = NULL;
-	}
-
-	if (e_mpi != NULL) {
-		gcry_mpi_release (e_mpi);
-		e_mpi = NULL;
-	}
+	keyutil_keyinfo_free(&keyinfo);
 
 	if (sexp != NULL) {
 		gcry_sexp_release (sexp);

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -583,7 +583,7 @@ static struct curve_info_map_s curve_info_map[] = {
 	{"1.2.840.10045.3.1.7", "082A8648CE3D030107"},
 
 	/* secp256k1 */
-	{"secp256k1", "052b8104000a"},
+	{"secp256k1", "052B8104000A"},
 	{"1.3.132.0.10", "052B8104000A"},
 
 	/* Terminator */

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -220,6 +220,8 @@ ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length) {
 		case KEYINFO_KEY_TYPE_INVALID:
 			return -1;
 	}
+
+	return -1;
 }
 
 int keyinfo_get_key_length(keyinfo keyinfo) {

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -284,21 +284,21 @@ keyinfo_from_der(
 			}
 			break;
 		case KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE:
-			/* Warning: EVP_PKEY_get1_EC_KEY is depreacted in OpenSSL 3.0 */
+			/* Warning: EVP_PKEY_get1_EC_KEY is deprecated in OpenSSL 3.0 */
 			ec_key = EVP_PKEY_get1_EC_KEY(pubkey);
 			if (ec_key == NULL) {
 				error = GPG_ERR_BAD_KEY;
 				goto cleanup;
 			}
 
-			/* Warning: EC_KEY_get0_public_key is depreacted in OpenSSL 3.0 */
+			/* Warning: EC_KEY_get0_public_key is deprecated in OpenSSL 3.0 */
 			ec_pubkey = EC_KEY_get0_public_key(ec_key);
 			if (ec_pubkey == NULL) {
 				error = GPG_ERR_BAD_KEY;
 				goto cleanup;
 			}
 
-			/* Warning: EC_KEY_get0_group is depreacted in OpenSSL 3.0 */
+			/* Warning: EC_KEY_get0_group is deprecated in OpenSSL 3.0 */
 			ec_group = EC_KEY_get0_group(ec_key);
 			if (ec_group == NULL) {
 				error = GPG_ERR_BAD_KEY;

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -163,8 +163,8 @@ static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const
 }
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-static int EVP_PKEY_get_base_id(const EVP_PKEY *pkey) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20500030L)
+static int EVP_PKEY_base_id(const EVP_PKEY *pkey) {
 	return(EVP_PKEY_type(pkey->type));
 }
 #endif
@@ -256,11 +256,11 @@ keyinfo_from_der(
 		goto cleanup;
 	}
 
-	if (EVP_PKEY_get_base_id(pubkey) == EVP_PKEY_EC) {
+	if (EVP_PKEY_base_id(pubkey) == EVP_PKEY_EC) {
 		keyinfo_init(keyinfo, KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE);
 	}
 
-	if (EVP_PKEY_get_base_id(pubkey) == EVP_PKEY_RSA) {
+	if (EVP_PKEY_base_id(pubkey) == EVP_PKEY_RSA) {
 		keyinfo_init(keyinfo, KEYINFO_KEY_TYPE_RSA);
 	}
 

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -272,6 +272,7 @@ keyinfo_from_der(
 				goto cleanup;
 			}
 
+			/* Warning: RSA_get0_key is deprecated in OpenSSL 3.0 */
 			RSA_get0_key(rsa, &n, &e, NULL);
 
 			n_hex = BN_bn2hex (n);
@@ -573,6 +574,8 @@ struct curve_info_map_s {
  * https://www.gnupg.org/documentation/manuals/gcrypt/ECC-key-parameters.html)
  * to GnuPG SCD protocol Curve value which is the DER-encoded OID minus the
  * tag (byte 0x06)
+ *
+ * The curve names must exist in GnuPG's openpgp-oid.c
  */
 static struct curve_info_map_s curve_info_map[] = {
 	/* secp256r1 */

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -163,7 +163,7 @@ static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const
 }
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x30000000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 static int EVP_PKEY_get_base_id(const EVP_PKEY *pkey) {
 	return(EVP_PKEY_type(pkey->type));
 }

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -41,14 +41,27 @@
 #include "keyutil.h"
 
 struct keyinfo_s {
+	/**
+	 * Type of key
+	 */
 	keyinfo_key_type_t type;
+
+	/**
+	 * Key Length (in bits)
+	 */
 	unsigned int key_length;
 	union {
+		/**
+		 * RSA Public Key
+		 */
 		struct {
 			gcry_mpi_t n;
 			gcry_mpi_t e;
 		} rsa;
 
+		/**
+		 * EcDSA Public Key (named curve)
+		 */
 		struct {
 			gcry_mpi_t q;
 			char *named_curve;
@@ -172,6 +185,18 @@ ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length) {
 		case KEYINFO_KEY_TYPE_INVALID:
 			abort();
 	}
+}
+
+int keyinfo_get_key_length(keyinfo keyinfo) {
+	return(keyinfo->key_length);
+}
+
+const char *keyinfo_get_key_named_curve(keyinfo keyinfo) {
+	if (keyinfo->type != KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE) {
+		return(NULL);
+	}
+
+	return(keyinfo->data.ecdsa.named_curve);
 }
 
 #if defined(ENABLE_OPENSSL)

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -370,7 +370,7 @@ keyinfo_from_der(
 			RSA_get0_key(rsa, &n, &e, NULL);
 
 			/* Warning: RSA_size is deprecated in OpenSSL 3.0 */
-			keyinfo->key_length = RSA_size(rsa);
+			keyinfo->key_length = RSA_size(rsa) * 8;
 
 			n_hex = BN_bn2hex (n);
 			e_hex = BN_bn2hex (e);

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -97,12 +97,12 @@ keyinfo keyinfo_new(void) {
 
 	keyinfo = malloc(sizeof(*keyinfo));
 	if (keyinfo == NULL) {
-		return(NULL);
+		return NULL;
 	}
 
 	keyinfo_init(keyinfo, KEYINFO_KEY_TYPE_UNKNOWN);
 
-	return(keyinfo);
+	return keyinfo;
 }
 
 /**
@@ -155,14 +155,14 @@ keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo) {
 		abort();
 	}
 
-	return(keyinfo->type);
+	return keyinfo->type;
 }
 
 ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length) {
 	unsigned int key_length;
 
 	if (keyinfo == NULL) {
-		return(-1);
+		return -1;
 	}
 
 	key_length = keyinfo->key_length / 8;
@@ -170,33 +170,33 @@ ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length) {
 	switch (keyinfo->type) {
 		case KEYINFO_KEY_TYPE_RSA:
 			if (input_length > key_length) {
-				return(-1);
+				return -1;
 			} else {
-				return(input_length);
+				return input_length;
 			}
 		case KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE:
 			if (input_length > key_length) {
-				return(key_length);
+				return key_length;
 			} else {
-				return(input_length);
+				return input_length;
 			}
 		case KEYINFO_KEY_TYPE_UNKNOWN:
-			return(-1);
+			return -1;
 		case KEYINFO_KEY_TYPE_INVALID:
 			abort();
 	}
 }
 
 int keyinfo_get_key_length(keyinfo keyinfo) {
-	return(keyinfo->key_length);
+	return keyinfo->key_length;
 }
 
 const char *keyinfo_get_key_named_curve(keyinfo keyinfo) {
 	if (keyinfo->type != KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE) {
-		return(NULL);
+		return NULL;
 	}
 
-	return(keyinfo->data.ecdsa.named_curve);
+	return keyinfo->data.ecdsa.named_curve;
 }
 
 #if defined(ENABLE_OPENSSL)
@@ -222,7 +222,7 @@ static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20500030L)
 static int EVP_PKEY_base_id(const EVP_PKEY *pkey) {
-	return(EVP_PKEY_type(pkey->type));
+	return EVP_PKEY_type(pkey->type);
 }
 #endif
 
@@ -657,11 +657,11 @@ static unsigned char *_keyinfo_lookup_named_curve(const char *named_curve) {
 
 	for (curr = curve_info_map; curr->curve_name != NULL; curr++) {
 		if (strcmp(curr->curve_name, named_curve) == 0) {
-			return((unsigned char *) curr->curve_gpg_value);
+			return (unsigned char *) curr->curve_gpg_value;
 		}
 	}
 
-	return(NULL);
+	return NULL;
 }
 
 keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
@@ -676,7 +676,7 @@ keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
 	}
 
 	if (keyinfo->type != KEYINFO_KEY_TYPE_UNKNOWN) {
-		return(NULL);
+		return NULL;
 	}
 
 	switch (keyinfo->type) {
@@ -818,5 +818,5 @@ keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
 		curve_item = NULL;
 	}
 
-	return(first);
+	return first;
 }

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -544,6 +544,18 @@ void keyinfo_data_free(keyinfo_data_list list) {
 	for (curr = list; curr != NULL; curr = next) {
 		next = curr->next;
 
+		if (curr->value != NULL) {
+			if (curr->value_free != NULL) {
+				curr->value_free(curr->value);
+			}
+		}
+
+		if (curr->tag != NULL) {
+			if (curr->tag_free != NULL) {
+				curr->tag_free(curr->tag);
+			}
+		}
+
 		free(curr);
 	}
 }
@@ -588,6 +600,9 @@ keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
 			e_item->type = (unsigned char *) "KEY-DATA";
 			e_item->tag = (unsigned char *) "e";
 			e_item->value = e_hex;
+			e_item->value_free = gcry_free;
+			e_item->tag_free = NULL;
+			e_hex = NULL;
 
 			n_item = malloc(sizeof(*n_item));
 			if (n_item == NULL) {
@@ -595,8 +610,11 @@ keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
 			}
 			n_item->next = e_item;
 			n_item->type = (unsigned char *) "KEY-DATA";
-			e_item->tag = (unsigned char *) "n";
+			n_item->tag = (unsigned char *) "n";
 			n_item->value = n_hex;
+			n_item->value_free = gcry_free;
+			n_item->tag_free = NULL;
+			n_hex = NULL;
 
 			first = n_item;
 			n_item = NULL;

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -571,14 +571,22 @@ struct curve_info_map_s {
 /**
  * Mapping of libgcrypt supported Curve names (found
  * https://www.gnupg.org/documentation/manuals/gcrypt/ECC-key-parameters.html)
- * to GnuPG SCD protocol Curve names (found ???)
+ * to GnuPG SCD protocol Curve value which is the DER-encoded OID minus the
+ * tag (byte 0x06)
  */
 static struct curve_info_map_s curve_info_map[] = {
-	{"NIST P-256", "???"},
-	{"secp256r1", "???"},
-	{"nistp256", "???"},
-	{"prime256v1", "???"},
-	{"1.2.840.10045.3.1.7", "???"},
+	/* secp256r1 */
+	{"NIST P-256", "082A8648CE3D030107"},
+	{"secp256r1", "082A8648CE3D030107"},
+	{"nistp256", "082A8648CE3D030107"},
+	{"prime256v1", "082A8648CE3D030107"},
+	{"1.2.840.10045.3.1.7", "082A8648CE3D030107"},
+
+	/* secp256k1 */
+	{"secp256k1", "052b8104000a"},
+	{"1.3.132.0.10", "052B8104000A"},
+
+	/* Terminator */
 	{NULL, NULL}
 };
 

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -137,10 +137,8 @@ void keyinfo_free(keyinfo keyinfo) {
 			}
 			break;
 		case KEYINFO_KEY_TYPE_UNKNOWN:
-			/* Nothing to do for unknown types */
-			break;
 		case KEYINFO_KEY_TYPE_INVALID:
-			abort();
+			/* Nothing to do for unknown types */
 			break;
 	}
 
@@ -151,10 +149,6 @@ void keyinfo_free(keyinfo keyinfo) {
 }
 
 keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo) {
-	if (keyinfo->type == KEYINFO_KEY_TYPE_INVALID) {
-		abort();
-	}
-
 	return keyinfo->type;
 }
 
@@ -181,9 +175,8 @@ ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length) {
 				return input_length;
 			}
 		case KEYINFO_KEY_TYPE_UNKNOWN:
-			return -1;
 		case KEYINFO_KEY_TYPE_INVALID:
-			abort();
+			return -1;
 	}
 }
 
@@ -393,10 +386,8 @@ keyinfo_from_der(
 			}
 			break;
 		case KEYINFO_KEY_TYPE_UNKNOWN:
-			error = GPG_ERR_BAD_KEY;
-			goto cleanup;
 		case KEYINFO_KEY_TYPE_INVALID:
-			abort();
+			error = GPG_ERR_BAD_KEY;
 			goto cleanup;
 	}
 #else
@@ -424,11 +415,9 @@ keyinfo_from_der(
 			error = GPG_ERR_NO_ERROR;
 			break;
 		case KEYINFO_KEY_TYPE_UNKNOWN:
+		case KEYINFO_KEY_TYPE_INVALID:
 			error = GPG_ERR_BAD_KEY;
 			goto cleanup;
-			break;
-		case KEYINFO_KEY_TYPE_INVALID:
-			abort();
 			break;
 	}
 
@@ -541,10 +530,8 @@ gcry_sexp_t keyinfo_to_sexp(keyinfo keyinfo) {
 			);
 			break;
 		case KEYINFO_KEY_TYPE_UNKNOWN:
-			sexp_build_result = 1;
-			break;
 		case KEYINFO_KEY_TYPE_INVALID:
-			abort();
+			sexp_build_result = 1;
 			break;
 	}
 
@@ -672,7 +659,7 @@ keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
 	unsigned char *curve_value = NULL;
 
 	if (keyinfo->type == KEYINFO_KEY_TYPE_INVALID) {
-		abort();
+		return NULL;
 	}
 
 	if (keyinfo->type != KEYINFO_KEY_TYPE_UNKNOWN) {
@@ -773,9 +760,8 @@ keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
 			curve_value = NULL;
 			break;
 		case KEYINFO_KEY_TYPE_UNKNOWN:
-			break;
 		case KEYINFO_KEY_TYPE_INVALID:
-			abort();
+			break;
 	}
 
 	if (n_hex != NULL) {

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -163,6 +163,12 @@ static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const
 }
 #endif
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L || defined(LIBRESSL_VERSION_NUMBER)
+static int EVP_PKEY_get_base_id(const EVP_PKEY *pkey) {
+	return(EVP_PKEY_type(pkey->type));
+}
+#endif
+
 #endif
 
 /**

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -40,13 +40,6 @@
 #include "encoding.h"
 #include "keyutil.h"
 
-#if defined(ENABLE_OPENSSL)
-#if OPENSSL_VERSION_NUMBER < 0x00908000L
-typedef unsigned char *my_openssl_d2i_t;
-#else
-typedef const unsigned char *my_openssl_d2i_t;
-#endif
-
 struct keyinfo_s {
 	keyinfo_key_type_t type;
 	union {
@@ -148,6 +141,13 @@ keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo) {
 
 	return(keyinfo->type);
 }
+
+#if defined(ENABLE_OPENSSL)
+#if OPENSSL_VERSION_NUMBER < 0x00908000L
+typedef unsigned char *my_openssl_d2i_t;
+#else
+typedef const unsigned char *my_openssl_d2i_t;
+#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d) {

--- a/gnupg-pkcs11-scd/keyutil.h
+++ b/gnupg-pkcs11-scd/keyutil.h
@@ -31,12 +31,35 @@
 #ifndef __KEYUTIL_H
 #define __KEYUTIL_H
 
+#include "common.h"
+
+typedef enum {
+	KEYUTIL_KEY_TYPE_UNKNOWN,
+	KEYUTIL_KEY_TYPE_RSA,
+	KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE
+} keyutil_key_type_t;
+
+typedef struct {
+	keyutil_key_type_t type;
+	union {
+		struct {
+			gcry_mpi_t n;
+			gcry_mpi_t e;
+		} rsa;
+
+		struct {
+			gcry_mpi_t q;
+			char *named_curve;
+			int named_curve_free;
+		} ecdsa;
+	} data;
+} keyutil_keyinfo_t;
+
 gpg_err_code_t
 keyutil_get_cert_mpi (
 	unsigned char *der,
 	size_t len,
-	gcry_mpi_t *p_n_mpi,
-	gcry_mpi_t *p_e_mpi
+	keyutil_keyinfo_t *key_info
 );
 
 gpg_err_code_t
@@ -47,5 +70,7 @@ keyutil_get_cert_sexp (
 );
 
 char *keyutil_get_cert_hexgrip (gcry_sexp_t sexp);
+void keyutil_keyinfo_init(keyutil_keyinfo_t *keyinfo, keyutil_key_type_t keytype);
+void keyutil_keyinfo_free(keyutil_keyinfo_t *keyinfo);
 
 #endif

--- a/gnupg-pkcs11-scd/keyutil.h
+++ b/gnupg-pkcs11-scd/keyutil.h
@@ -75,6 +75,18 @@ keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo);
 ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length);
 
 /**
+ * Get the size of the key (in bits)
+ */
+int keyinfo_get_key_length(keyinfo keyinfo);
+
+/**
+ * Get the named curve for a key (or NULL if there is no named curve or it's
+ * not applicable).  The returned data has the same lifetime of the keyinfo
+ * input.
+ */
+const char *keyinfo_get_key_named_curve(keyinfo keyinfo);
+
+/**
  * Parse a DER-encoded X.509 certificate into a key
  */
 gpg_err_code_t keyinfo_from_der(keyinfo keyinfo, unsigned char *der, size_t len);

--- a/gnupg-pkcs11-scd/keyutil.h
+++ b/gnupg-pkcs11-scd/keyutil.h
@@ -46,8 +46,10 @@ typedef struct keyinfo_s *keyinfo;
 struct keyinfo_data_list_s {
 	struct keyinfo_data_list_s *next;
 	unsigned char *type;
-	unsigned char *value;
 	unsigned char *tag;
+	unsigned char *value;
+	void (*value_free)(void *);
+	void (*tag_free)(void *);
 };
 typedef struct keyinfo_data_list_s *keyinfo_data_list;
 

--- a/gnupg-pkcs11-scd/keyutil.h
+++ b/gnupg-pkcs11-scd/keyutil.h
@@ -34,43 +34,63 @@
 #include "common.h"
 
 typedef enum {
-	KEYUTIL_KEY_TYPE_UNKNOWN,
-	KEYUTIL_KEY_TYPE_RSA,
-	KEYUTIL_KEY_TYPE_ECDSA_NAMED_CURVE
-} keyutil_key_type_t;
+	KEYINFO_KEY_TYPE_INVALID = -1,
+	KEYINFO_KEY_TYPE_UNKNOWN = 0,
+	KEYINFO_KEY_TYPE_RSA,
+	KEYINFO_KEY_TYPE_ECDSA_NAMED_CURVE
+} keyinfo_key_type_t;
 
-typedef struct {
-	keyutil_key_type_t type;
-	union {
-		struct {
-			gcry_mpi_t n;
-			gcry_mpi_t e;
-		} rsa;
+struct keyinfo_s;
+typedef struct keyinfo_s *keyinfo;
 
-		struct {
-			gcry_mpi_t q;
-			char *named_curve;
-			int named_curve_free;
-		} ecdsa;
-	} data;
-} keyutil_keyinfo_t;
+struct keyinfo_data_list_s {
+	struct keyinfo_data_list_s *next;
+	unsigned char *type;
+	unsigned char *value;
+	unsigned char *tag;
+};
+typedef struct keyinfo_data_list_s *keyinfo_data_list;
 
-gpg_err_code_t
-keyutil_get_cert_mpi (
-	unsigned char *der,
-	size_t len,
-	keyutil_keyinfo_t *key_info
-);
 
-gpg_err_code_t
-keyutil_get_cert_sexp (
-	unsigned char *der,
-	size_t len,
-	gcry_sexp_t *p_sexp
-);
+/**
+ * Instantiate a new key
+ */
+keyinfo keyinfo_new(void);
 
-char *keyutil_get_cert_hexgrip (gcry_sexp_t sexp);
-void keyutil_keyinfo_init(keyutil_keyinfo_t *keyinfo, keyutil_key_type_t keytype);
-void keyutil_keyinfo_free(keyutil_keyinfo_t *keyinfo);
+/**
+ * Free a key
+ */
+void keyinfo_free(keyinfo keyinfo);
+
+/**
+ * Get the Key Type (RSA, ECDSA) from a key
+ */
+keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo);
+
+/**
+ * Parse a DER-encoded X.509 certificate into a key
+ */
+gpg_err_code_t keyinfo_from_der(keyinfo keyinfo, unsigned char *der, size_t len);
+
+/**
+ * Produce a libgcrypt S-expression representing a key
+ */
+gcry_sexp_t keyinfo_to_sexp(keyinfo keyinfo);
+
+/**
+ * Produce a "hexgrip" from a libgcrypt S-expression representing a key
+ */
+char *keyinfo_get_hexgrip(gcry_sexp_t sexp);
+
+/**
+ * Get the serialized form of a key, in parts as a linked list
+ */
+keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo);
+
+/**
+ * Free the list of serialized parts of a key
+ */
+void keyinfo_data_free(keyinfo_data_list list);
+
 
 #endif

--- a/gnupg-pkcs11-scd/keyutil.h
+++ b/gnupg-pkcs11-scd/keyutil.h
@@ -70,6 +70,11 @@ void keyinfo_free(keyinfo keyinfo);
 keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo);
 
 /**
+ * Get the size of data which may be signed/encrypted
+ */
+ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length);
+
+/**
  * Parse a DER-encoded X.509 certificate into a key
  */
 gpg_err_code_t keyinfo_from_der(keyinfo keyinfo, unsigned char *der, size_t len);


### PR DESCRIPTION
This changeset adds support for EcDSA Keys with Named Curves.  Additionally, it may make it easier to add other kinds of keys in the future.

Not done as part of this change:
Support GnuTLS