### PR TITLE
Fix bug where stack data is free'd

### DIFF
--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1999,7 +1999,7 @@ gpg_error_t cmd_genkey (assuan_context_t ctx, char *line)
 
 	if (timestamp == NULL) {
 		sprintf (_timestamp, "%d", (int)time (NULL));
-		timestamp = _timestamp;
+		timestamp = strdup(_timestamp);
 	}
 
 	if (


### PR DESCRIPTION
This change fixes a bug where data allocated on the stack may be attempted to be `free`'d