### PR TITLE
Fix bug where NULL data could be free'd

### DIFF
--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1376,10 +1376,15 @@ cleanup:
 	}
 
 	if (need_free__data) {
-		free (_data->data);
-		_data->data = NULL;
-		free (_data);
-		_data = NULL;
+		if (_data != NULL) {
+			if (_data->data != NULL) {
+				free (_data->data);
+				_data->data = NULL;
+			}
+
+			free (_data);
+			_data = NULL;
+		}
 	}
 
 	strgetopt_free(options);


### PR DESCRIPTION
This change fixes calls to `free()` on data that may be NULL if `malloc()` were to fail.