### PR TITLE
Add support for non-PKCS1 Signing

### DIFF
--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -125,6 +125,30 @@ keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo) {
 	return keyinfo->type;
 }
 
+ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length) {
+	unsigned int key_length;
+
+	if (keyinfo == NULL) {
+		return -1;
+	}
+
+	key_length = keyinfo->key_length / 8;
+
+	switch (keyinfo->type) {
+		case KEYINFO_KEY_TYPE_RSA:
+			if (input_length > key_length) {
+				return -1;
+			} else {
+				return input_length;
+			}
+		case KEYINFO_KEY_TYPE_UNKNOWN:
+		case KEYINFO_KEY_TYPE_INVALID:
+			return -1;
+	}
+
+	return -1;
+}
+
 int keyinfo_get_key_length(keyinfo keyinfo) {
 	return keyinfo->key_length;
 }

--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -35,9 +35,99 @@
 #if defined(ENABLE_OPENSSL)
 #include <openssl/x509.h>
 #include <openssl/rsa.h>
+#include <openssl/evp.h>
 #endif
 #include "encoding.h"
 #include "keyutil.h"
+
+struct keyinfo_s {
+	/**
+	 * Type of key
+	 */
+	keyinfo_key_type_t type;
+
+	/**
+	 * Key Length (in bits)
+	 */
+	unsigned int key_length;
+	union {
+		/**
+		 * RSA Public Key
+		 */
+		struct {
+			gcry_mpi_t n;
+			gcry_mpi_t e;
+		} rsa;
+	} data;
+};
+
+/**
+ * Initialize a KeyUtil KeyInfo Object
+ */
+void keyinfo_init(keyinfo keyinfo, keyinfo_key_type_t keytype) {
+	keyinfo->type = keytype;
+	keyinfo->key_length = 0;
+
+	if (keyinfo->type == KEYINFO_KEY_TYPE_RSA || keyinfo->type == KEYINFO_KEY_TYPE_UNKNOWN) {
+		keyinfo->data.rsa.e = NULL;
+		keyinfo->data.rsa.n = NULL;
+	}
+}
+
+/**
+ * Allocate a new KeyInfo object
+ */
+keyinfo keyinfo_new(void) {
+	keyinfo keyinfo;
+
+	keyinfo = malloc(sizeof(*keyinfo));
+	if (keyinfo == NULL) {
+		return NULL;
+	}
+
+	keyinfo_init(keyinfo, KEYINFO_KEY_TYPE_UNKNOWN);
+
+	return keyinfo;
+}
+
+/**
+ * Free any resources held by a KeyUtil KeyInfo object.
+ */
+void keyinfo_free(keyinfo keyinfo) {
+	if (keyinfo == NULL) {
+		return;
+	}
+
+	switch (keyinfo->type) {
+		case KEYINFO_KEY_TYPE_RSA:
+			if (keyinfo->data.rsa.e) {
+				gcry_mpi_release(keyinfo->data.rsa.e);
+				keyinfo->data.rsa.e = NULL;
+			}
+			if (keyinfo->data.rsa.n) {
+				gcry_mpi_release(keyinfo->data.rsa.n);
+				keyinfo->data.rsa.n = NULL;
+			}
+			break;
+		case KEYINFO_KEY_TYPE_UNKNOWN:
+		case KEYINFO_KEY_TYPE_INVALID:
+			/* Nothing to do for unknown types */
+			break;
+	}
+
+	keyinfo->type = KEYINFO_KEY_TYPE_INVALID;
+	keyinfo->key_length = 0;
+
+	free(keyinfo);
+}
+
+keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo) {
+	return keyinfo->type;
+}
+
+int keyinfo_get_key_length(keyinfo keyinfo) {
+	return keyinfo->key_length;
+}
 
 #if defined(ENABLE_OPENSSL)
 #if OPENSSL_VERSION_NUMBER < 0x00908000L
@@ -60,15 +150,25 @@ static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const
 }
 #endif
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20500030L)
+static int EVP_PKEY_base_id(const EVP_PKEY *pkey) {
+	return EVP_PKEY_type(pkey->type);
+}
 #endif
 
+#endif
+
+/**
+ * Convert the public key from an X.509 certificate into an already-created
+ * key object
+ */
 gpg_err_code_t
-keyutil_get_cert_mpi (
+keyinfo_from_der(
+	keyinfo keyinfo,
 	unsigned char *der,
-	size_t len,
-	gcry_mpi_t *p_n_mpi,
-	gcry_mpi_t *p_e_mpi
+	size_t len
 ) {
+	struct curve_info_map_s *curr;
 	gpg_err_code_t error = GPG_ERR_GENERAL;
 	gcry_mpi_t n_mpi = NULL;
 	gcry_mpi_t e_mpi = NULL;
@@ -77,15 +177,14 @@ keyutil_get_cert_mpi (
 	gnutls_datum_t datum = {der, len};
 	gnutls_datum_t m = {NULL, 0}, e = {NULL, 0};
 #elif defined(ENABLE_OPENSSL)
+	int check_result;
 	X509 *x509 = NULL;
 	EVP_PKEY *pubkey = NULL;
+	EVP_PKEY_CTX *pubkey_ctx = NULL;
 	RSA *rsa = NULL;
 	const BIGNUM *n, *e;
 	char *n_hex = NULL, *e_hex = NULL;
 #endif
-
-	*p_n_mpi = NULL;
-	*p_e_mpi = NULL;
 
 #if defined(ENABLE_GNUTLS)
 	if (gnutls_x509_crt_init (&cert) != GNUTLS_E_SUCCESS) {
@@ -118,43 +217,87 @@ keyutil_get_cert_mpi (
 		error = GPG_ERR_BAD_CERT;
 		goto cleanup;
 	}
- 
+
 	if ((pubkey = X509_get_pubkey (x509)) == NULL) {
 		error = GPG_ERR_BAD_CERT;
 		goto cleanup;
 	}
- 
-	if ((rsa = EVP_PKEY_get1_RSA(pubkey)) == NULL) {
+
+	pubkey_ctx = EVP_PKEY_CTX_new(pubkey, NULL);
+	if (pubkey_ctx == NULL) {
+		error = GPG_ERR_BAD_CERT;
+		goto cleanup;
+	}
+
+	/**
+	 * Check the public key context
+	 * 1 is success, -2 is not applicable
+	 */
+	check_result = EVP_PKEY_public_check(pubkey_ctx);
+	if (check_result != 1 && check_result != -2) {
 		error = GPG_ERR_WRONG_PUBKEY_ALGO;
 		goto cleanup;
 	}
 
-	RSA_get0_key(rsa, &n, &e, NULL);
-
-	n_hex = BN_bn2hex (n);
-	e_hex = BN_bn2hex (e);
-
-	if(n_hex == NULL || e_hex == NULL) {
-		error = GPG_ERR_BAD_KEY;
-		goto cleanup;
+	if (EVP_PKEY_base_id(pubkey) == EVP_PKEY_RSA) {
+		keyinfo_init(keyinfo, KEYINFO_KEY_TYPE_RSA);
 	}
- 
-	if (
-		gcry_mpi_scan (&n_mpi, GCRYMPI_FMT_HEX, n_hex, 0, NULL) ||
-		gcry_mpi_scan (&e_mpi, GCRYMPI_FMT_HEX, e_hex, 0, NULL)
-	) {
-		error = GPG_ERR_BAD_KEY;
-		goto cleanup;
+
+	switch (keyinfo->type) {
+		case KEYINFO_KEY_TYPE_RSA:
+			/* Warning: EVP_PKEY_get1_RSA is deprecated in OpenSSL 3.0 */
+			if ((rsa = EVP_PKEY_get1_RSA(pubkey)) == NULL) {
+				error = GPG_ERR_WRONG_PUBKEY_ALGO;
+				goto cleanup;
+			}
+
+			/* Warning: RSA_get0_key is deprecated in OpenSSL 3.0 */
+			RSA_get0_key(rsa, &n, &e, NULL);
+
+			/* Warning: RSA_size is deprecated in OpenSSL 3.0 */
+			keyinfo->key_length = RSA_size(rsa) * 8;
+
+			n_hex = BN_bn2hex (n);
+			e_hex = BN_bn2hex (e);
+
+			if(n_hex == NULL || e_hex == NULL) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+
+			if (
+				gcry_mpi_scan (&n_mpi, GCRYMPI_FMT_HEX, n_hex, 0, NULL) ||
+				gcry_mpi_scan (&e_mpi, GCRYMPI_FMT_HEX, e_hex, 0, NULL)
+			) {
+				error = GPG_ERR_BAD_KEY;
+				goto cleanup;
+			}
+			break;
+		case KEYINFO_KEY_TYPE_UNKNOWN:
+		case KEYINFO_KEY_TYPE_INVALID:
+			error = GPG_ERR_BAD_KEY;
+			goto cleanup;
 	}
 #else
 #error Invalid configuration.
 #endif
 
-	*p_n_mpi = n_mpi;
-	n_mpi = NULL;
-	*p_e_mpi = e_mpi;
-	e_mpi = NULL;
-	error = GPG_ERR_NO_ERROR;
+	switch (keyinfo->type) {
+		case KEYINFO_KEY_TYPE_RSA:
+			keyinfo->data.rsa.n = n_mpi;
+			n_mpi = NULL;
+
+			keyinfo->data.rsa.e = e_mpi;
+			e_mpi = NULL;
+
+			error = GPG_ERR_NO_ERROR;
+			break;
+		case KEYINFO_KEY_TYPE_UNKNOWN:
+		case KEYINFO_KEY_TYPE_INVALID:
+			error = GPG_ERR_BAD_KEY;
+			goto cleanup;
+			break;
+	}
 
 cleanup:
 
@@ -192,12 +335,18 @@ cleanup:
 		x509 = NULL;
 	}
 
+	if (pubkey_ctx) {
+		EVP_PKEY_CTX_free(pubkey_ctx);
+		pubkey_ctx = NULL;
+	}
+
 	if (pubkey != NULL) {
 		EVP_PKEY_free(pubkey);
 		pubkey = NULL;
 	}
 
 	if (rsa != NULL) {
+		/* Warning: RSA_free is deprecated in OpenSSL 3.0 */
 		RSA_free(rsa);
 		rsa = NULL;
 	}
@@ -218,69 +367,42 @@ cleanup:
 
 	return error;
 }
-/**
-   Convert X.509 RSA public key into gcrypt internal sexp form. Only RSA
-   public keys are accepted at the moment. The result is stored in *sexp,
-   which must be freed (using ) when not needed anymore. *sexp must be
-   NULL on entry, since it is overwritten.
-*/
-gpg_err_code_t
-keyutil_get_cert_sexp (
-	unsigned char *der,
-	size_t len,
-	gcry_sexp_t *p_sexp
-) {
-	gpg_err_code_t error = GPG_ERR_GENERAL;
-	gcry_mpi_t n_mpi = NULL;
-	gcry_mpi_t e_mpi = NULL;
-	gcry_sexp_t sexp = NULL;
 
-	if (
-		(error = keyutil_get_cert_mpi (
-			der,
-			len,
-			&n_mpi,
-			&e_mpi
-		)) != GPG_ERR_NO_ERROR
-	) {
+gcry_sexp_t keyinfo_to_sexp(keyinfo keyinfo) {
+	gcry_sexp_t sexp = NULL, complete_sexp = NULL;
+	gcry_error_t sexp_build_result;
+
+	switch (keyinfo->type) {
+		case KEYINFO_KEY_TYPE_RSA:
+			sexp_build_result = gcry_sexp_build(
+				&sexp,
+				NULL,
+				"(public-key (rsa (n %m) (e %m)))",
+				keyinfo->data.rsa.n,
+				keyinfo->data.rsa.e
+			);
+			break;
+		case KEYINFO_KEY_TYPE_UNKNOWN:
+		case KEYINFO_KEY_TYPE_INVALID:
+			sexp_build_result = 1;
+			break;
+	}
+
+	if (sexp_build_result != 0) {
 		goto cleanup;
 	}
 
-	if (
-		gcry_sexp_build (
-			&sexp,
-			NULL,
-			"(public-key (rsa (n %m) (e %m)))",
-			n_mpi,
-			e_mpi
-		)
-	) {
-		error = GPG_ERR_BAD_KEY;
-		goto cleanup;
-	}
-
-	*p_sexp = sexp;
+	complete_sexp = sexp;
 	sexp = NULL;
-	error = GPG_ERR_NO_ERROR;
 
 cleanup:
-
-	if (n_mpi != NULL) {
-		gcry_mpi_release (n_mpi);
-		n_mpi = NULL;
-	}
-
-	if (e_mpi != NULL) {
-		gcry_mpi_release (e_mpi);
-		e_mpi = NULL;
-	}
 
 	if (sexp != NULL) {
 		gcry_sexp_release (sexp);
 		sexp = NULL;
 	}
 
-	return error;
+	return complete_sexp;
 }
 
 #if 0
@@ -302,7 +424,7 @@ void cert_get_hexgrip(unsigned char *der, size_t len, char *certid)
 #endif
 
 /** Calculate hex-encoded keygrip of public key in sexp. */
-char *keyutil_get_cert_hexgrip (gcry_sexp_t sexp)
+char *keyinfo_get_hexgrip (gcry_sexp_t sexp)
 {
 	char *ret = NULL;
 	unsigned char grip[20];
@@ -312,4 +434,119 @@ char *keyutil_get_cert_hexgrip (gcry_sexp_t sexp)
 	}
 
 	return ret;
+}
+
+void keyinfo_data_free(keyinfo_data_list list) {
+	keyinfo_data_list next, curr;
+
+	if (list == NULL) {
+		return;
+	}
+
+	for (curr = list; curr != NULL; curr = next) {
+		next = curr->next;
+
+		if (curr->value != NULL) {
+			if (curr->value_free != NULL) {
+				curr->value_free(curr->value);
+			}
+		}
+
+		if (curr->tag != NULL) {
+			if (curr->tag_free != NULL) {
+				curr->tag_free(curr->tag);
+			}
+		}
+
+		free(curr);
+	}
+}
+
+keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo) {
+	keyinfo_data_list first = NULL, n_item = NULL, e_item = NULL;
+	unsigned char *n_hex = NULL;
+	unsigned char *e_hex = NULL;
+
+	if (keyinfo->type == KEYINFO_KEY_TYPE_INVALID) {
+		return NULL;
+	}
+
+	if (keyinfo->type != KEYINFO_KEY_TYPE_UNKNOWN) {
+		return NULL;
+	}
+
+	switch (keyinfo->type) {
+		case KEYINFO_KEY_TYPE_RSA:
+			if (
+				gcry_mpi_aprint (
+					GCRYMPI_FMT_HEX,
+					&n_hex,
+					NULL,
+					keyinfo->data.rsa.n
+				) ||
+				gcry_mpi_aprint (
+					GCRYMPI_FMT_HEX,
+					&e_hex,
+					NULL,
+					keyinfo->data.rsa.e
+				)
+			) {
+				break;
+			}
+
+			e_item = malloc(sizeof(*e_item));
+			if (e_item == NULL) {
+				break;
+			}
+			e_item->next = NULL;
+			e_item->type = (unsigned char *) "KEY-DATA";
+			e_item->tag = (unsigned char *) "e";
+			e_item->value = e_hex;
+			e_item->value_free = gcry_free;
+			e_item->tag_free = NULL;
+
+			n_item = malloc(sizeof(*n_item));
+			if (n_item == NULL) {
+				break;
+			}
+			n_item->next = e_item;
+			n_item->type = (unsigned char *) "KEY-DATA";
+			n_item->tag = (unsigned char *) "n";
+			n_item->value = n_hex;
+			n_item->value_free = gcry_free;
+			n_item->tag_free = NULL;
+
+			first = n_item;
+			n_item = NULL;
+			e_item = NULL;
+			n_hex = NULL;
+			e_hex = NULL;
+
+			break;
+		case KEYINFO_KEY_TYPE_UNKNOWN:
+		case KEYINFO_KEY_TYPE_INVALID:
+			break;
+	}
+
+	if (n_hex != NULL) {
+		gcry_free(n_hex);
+		n_hex = NULL;
+	}
+
+	if (e_hex != NULL) {
+		gcry_free(e_hex);
+		e_hex = NULL;
+	}
+
+	if (n_item != NULL) {
+		free(n_item);
+		n_item = NULL;
+	}
+
+	if (e_item != NULL) {
+		free(e_item);
+		e_item = NULL;
+	}
+
+	return first;
 }

--- a/gnupg-pkcs11-scd/keyutil.h
+++ b/gnupg-pkcs11-scd/keyutil.h
@@ -68,6 +68,11 @@ void keyinfo_free(keyinfo keyinfo);
 keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo);
 
 /**
+ * Get the size of data which may be signed/encrypted
+ */
+ssize_t keyinfo_get_data_length(keyinfo keyinfo, size_t input_length);
+
+/**
  * Get the size of the key (in bits)
  */
 int keyinfo_get_key_length(keyinfo keyinfo);

--- a/gnupg-pkcs11-scd/keyutil.h
+++ b/gnupg-pkcs11-scd/keyutil.h
@@ -31,21 +31,70 @@
 #ifndef __KEYUTIL_H
 #define __KEYUTIL_H
 
-gpg_err_code_t
-keyutil_get_cert_mpi (
-	unsigned char *der,
-	size_t len,
-	gcry_mpi_t *p_n_mpi,
-	gcry_mpi_t *p_e_mpi
-);
+#include "common.h"
 
-gpg_err_code_t
-keyutil_get_cert_sexp (
-	unsigned char *der,
-	size_t len,
-	gcry_sexp_t *p_sexp
-);
+typedef enum {
+	KEYINFO_KEY_TYPE_INVALID = -1,
+	KEYINFO_KEY_TYPE_UNKNOWN = 0,
+	KEYINFO_KEY_TYPE_RSA
+} keyinfo_key_type_t;
 
-char *keyutil_get_cert_hexgrip (gcry_sexp_t sexp);
+struct keyinfo_s;
+typedef struct keyinfo_s *keyinfo;
+
+struct keyinfo_data_list_s {
+	struct keyinfo_data_list_s *next;
+	unsigned char *type;
+	unsigned char *tag;
+	unsigned char *value;
+	void (*value_free)(void *);
+	void (*tag_free)(void *);
+};
+typedef struct keyinfo_data_list_s *keyinfo_data_list;
+
+/**
+ * Instantiate a new key
+ */
+keyinfo keyinfo_new(void);
+
+/**
+ * Free a key
+ */
+void keyinfo_free(keyinfo keyinfo);
+
+/**
+ * Get the Key Type (RSA) from a key
+ */
+keyinfo_key_type_t keyinfo_get_type(keyinfo keyinfo);
+
+/**
+ * Get the size of the key (in bits)
+ */
+int keyinfo_get_key_length(keyinfo keyinfo);
+
+/**
+ * Parse a DER-encoded X.509 certificate into a key
+ */
+gpg_err_code_t keyinfo_from_der(keyinfo keyinfo, unsigned char *der, size_t len);
+
+/**
+ * Produce a libgcrypt S-expression representing a key
+ */
+gcry_sexp_t keyinfo_to_sexp(keyinfo keyinfo);
+
+/**
+ * Produce a "hexgrip" from a libgcrypt S-expression representing a key
+ */
+char *keyinfo_get_hexgrip(gcry_sexp_t sexp);
+
+/**
+ * Get the serialized form of a key, in parts as a linked list
+ */
+keyinfo_data_list keyinfo_get_key_data(keyinfo keyinfo);
+
+/**
+ * Free the list of serialized parts of a key
+ */
+void keyinfo_data_free(keyinfo_data_list list);
 
 #endif


### PR DESCRIPTION
This changeset adds support for signing mechanisms which do not use PKCS1 encoding, such as EcDSA.

Note:  It relies on support for multiple kinds of keys.