### PR TITLE
Fix token check with non-RSA non-standard certificate

### DIFF
--- a/gnupg-pkcs11-scd/keyutil.c
+++ b/gnupg-pkcs11-scd/keyutil.c
@@ -97,7 +97,7 @@ keyutil_get_cert_mpi (
 	}
 
 	if ((pubkey = X509_get_pubkey (x509)) == NULL) {
-		error = GPG_ERR_BAD_CERT;
+		error = GPG_ERR_WRONG_PUBKEY_ALGO;
 		goto cleanup;
 	}
 


### PR DESCRIPTION
In some rare case certificate on the token could not be supported by openssl without special engines/providers. This PR make to ignore such certificates.