### PR TITLE
Possible fix for issue #59 + segfault and leak fixes

### DIFF
--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -1631,7 +1631,7 @@ gpg_error_t cmd_keyinfo (assuan_context_t ctx, char *line)
 	char *list = NULL;
 	int data_arg = 0;
 	const char *l;
-	char *serial;
+	char *serial = NULL;
 	int found;
 
 	const struct strgetopt_option options[] = {

--- a/gnupg-pkcs11-scd/command.c
+++ b/gnupg-pkcs11-scd/command.c
@@ -651,6 +651,11 @@ int _get_certificate_by_name (assuan_context_t ctx, const char *name, int typehi
 			key_hexgrip = NULL;
 		}
 
+		if (error == GPG_ERR_WRONG_PUBKEY_ALGO) {
+			/* skip unsupported keys */
+			error = GPG_ERR_NO_ERROR;
+		}
+
 		if (error != GPG_ERR_NO_ERROR) {
 			goto cleanup;
 		}
@@ -1780,6 +1785,11 @@ gpg_error_t cmd_keyinfo (assuan_context_t ctx, char *line)
 		if (key_hexgrip != NULL) {
 			free (key_hexgrip);
 			key_hexgrip = NULL;
+		}
+
+		if (error == GPG_ERR_WRONG_PUBKEY_ALGO) {
+			/* skip unsupported keys */
+			error = GPG_ERR_NO_ERROR;
 		}
 
 		if (error != GPG_ERR_NO_ERROR) {


### PR DESCRIPTION
Fixing several issues in scd:

* There's a segfault in `cmd_keyinfo` - if the loop breaks before `serial` is initialized, `free()` will be called on it. Fixing by initializing `serial` to `NULL`

* In `_get_certificate_by_name` there's a possible memory leak when the loop runs more than once. Both `sexp` and `key_hexgrip` are allocated inside the loop but are only freed in `cleanup`. Moving their cleanup inside the loop body.

* Both of the above will break with an error when encountering a non-RSA certificate (checked by `keyutil_get_cert_mpi`). This means that cards with multiple keys, some RSA and some don't - may or may not work depending on the certificate enumeration order. I suspect this may cause #59. Fixing by not breaking the loop on `GPG_ERR_WRONG_PUBKEY_ALGO` and instead continue iterating to find compatible certificates.